### PR TITLE
feat: redirect authenticated users to Dashboard instead of Settings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useState } from 'react';
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route, useLocation, useNavigate } from 'react-router-dom';
 import { AppProvider } from './context/AppContext';
 import { ErrorBoundary } from './components/UI/ErrorBoundary';
 import { Sidebar } from './components/Layout/Sidebar';
@@ -13,7 +13,29 @@ import { Projects } from './pages/Projects';
 import { Goals } from './pages/Goals';
 import { Analytics } from './pages/Analytics';
 import { Settings } from './pages/Settings';
+import { useApp } from './context/useApp';
 
+// Settings wrapper component that redirects authenticated users to Dashboard
+function SettingsWrapper() {
+  const { state } = useApp();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { isAuthenticated, isDemoMode } = state.authentication;
+
+  React.useEffect(() => {
+    // If authenticated or in demo mode and on settings page, redirect to dashboard
+    if ((isAuthenticated || isDemoMode) && location.pathname === '/settings') {
+      navigate('/', { replace: true });
+    }
+  }, [isAuthenticated, isDemoMode, location.pathname, navigate]);
+
+  // Only render Settings if not authenticated and not in demo mode
+  if (isAuthenticated || isDemoMode) {
+    return null; // Will redirect via useEffect
+  }
+
+  return <Settings />;
+}
 
 function App() {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
@@ -53,7 +75,7 @@ function App() {
                       <Analytics />
                     </ProtectedRoute>
                   } />
-                  <Route path="/settings" element={<Settings />} />
+                  <Route path="/settings" element={<SettingsWrapper />} />
                 </Routes>
               </main>
             </div>

--- a/src/components/Auth/ProtectedRoute.tsx
+++ b/src/components/Auth/ProtectedRoute.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { useApp } from '../../context/useApp';
 import { LoadingSpinner } from '../UI/LoadingSpinner';
 
@@ -16,6 +16,7 @@ export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
 }) => {
   const { state } = useApp();
   const navigate = useNavigate();
+  const location = useLocation();
   const { isAuthenticated, isDemoMode } = state.authentication;
 
   useEffect(() => {
@@ -23,7 +24,12 @@ export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
     if (!isAuthenticated && !isDemoMode) {
       navigate('/settings', { replace: true });
     }
-  }, [isAuthenticated, isDemoMode, navigate]);
+    
+    // If authenticated and trying to access settings, redirect to dashboard
+    if ((isAuthenticated || isDemoMode) && location.pathname === '/settings') {
+      navigate('/', { replace: true });
+    }
+  }, [isAuthenticated, isDemoMode, navigate, location.pathname]);
 
   // Show loading spinner while checking authentication
   if (!isAuthenticated && !isDemoMode) {

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Search, Bell, User, Menu, LogOut, LogIn, Play, Shield, Lock } from 'lucide-react';
 import { useApp } from '../../context/useApp';
 import { AuthModal } from '../Auth/AuthModal';
@@ -11,6 +12,7 @@ interface HeaderProps {
 
 export function Header({ onMenuClick }: HeaderProps) {
   const { state, dispatch } = useApp();
+  const navigate = useNavigate();
   const [isAuthModalOpen, setIsAuthModalOpen] = useState(false);
   const [authMode, setAuthMode] = useState<'login' | 'register'>('login');
   const [authError, setAuthError] = useState<string | undefined>();
@@ -26,6 +28,8 @@ export function Header({ onMenuClick }: HeaderProps) {
       const user = await authenticateUser(email, password);
       dispatch({ type: 'LOGIN', payload: user });
       setIsAuthModalOpen(false);
+      // Redirect to Dashboard after successful login
+      navigate('/');
     } catch (error) {
       setAuthError(error instanceof Error ? error.message : 'Login failed. Please try again.');
     } finally {
@@ -41,6 +45,8 @@ export function Header({ onMenuClick }: HeaderProps) {
       const user = await registerUser(email, password, name);
       dispatch({ type: 'LOGIN', payload: user });
       setIsAuthModalOpen(false);
+      // Redirect to Dashboard after successful registration
+      navigate('/');
     } catch (error) {
       setAuthError(error instanceof Error ? error.message : 'Registration failed. Please try again.');
     } finally {
@@ -58,6 +64,8 @@ export function Header({ onMenuClick }: HeaderProps) {
 
   const handleSwitchToDemo = () => {
     dispatch({ type: 'SWITCH_TO_DEMO' });
+    // Redirect to Dashboard after entering demo mode
+    navigate('/');
   };
 
   const handleSwitchToAuth = () => {

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Card } from '../components/UI/Card';
 import { Button } from '../components/UI/Button';
 import { useApp } from '../context/useApp';
@@ -11,6 +12,7 @@ import { logger } from '../utils/logger';
 
 export function Settings() {
   const { state, dispatch } = useApp();
+  const navigate = useNavigate();
   const [isAuthModalOpen, setIsAuthModalOpen] = useState(false);
   const [authMode, setAuthMode] = useState<'login' | 'register'>('login');
   const [authError, setAuthError] = useState<string | undefined>();
@@ -42,6 +44,8 @@ export function Settings() {
       const user = await authenticateUser(email, password);
       dispatch({ type: 'LOGIN', payload: user });
       setIsAuthModalOpen(false);
+      // Redirect to Dashboard after successful login
+      navigate('/');
     } catch (error) {
       setAuthError(error instanceof Error ? error.message : 'Login failed. Please try again.');
     } finally {
@@ -57,6 +61,8 @@ export function Settings() {
       const user = await registerUser(email, password, name);
       dispatch({ type: 'LOGIN', payload: user });
       setIsAuthModalOpen(false);
+      // Redirect to Dashboard after successful registration
+      navigate('/');
     } catch (error) {
       setAuthError(error instanceof Error ? error.message : 'Registration failed. Please try again.');
     } finally {
@@ -103,6 +109,8 @@ export function Settings() {
             <button
               onClick={() => {
                 dispatch({ type: 'SWITCH_TO_DEMO' });
+                // Redirect to Dashboard after entering demo mode
+                navigate('/');
               }}
               className="px-6 py-3 border border-stone-600 hover:border-stone-500 text-stone-300 hover:text-stone-200 rounded-lg font-medium transition-colors flex items-center justify-center space-x-2"
             >
@@ -143,6 +151,8 @@ export function Settings() {
 
   const handleSwitchToDemo = () => {
     dispatch({ type: 'SWITCH_TO_DEMO' });
+    // Redirect to Dashboard after entering demo mode
+    navigate('/');
   };
 
 


### PR DESCRIPTION
- Add navigation redirects after login/registration in Settings and Header
- Create SettingsWrapper component to prevent authenticated access to Settings
- Update ProtectedRoute to redirect authenticated users away from Settings
- Ensure demo mode users also land on Dashboard after entering demo mode
- Improve UX by taking users directly to main app interface after auth